### PR TITLE
Update `react-instasearch` link to point to `instasearch` monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository describes the steps to integrate a relevant front-end search bar
 ## Installation
 
 To integrate a front-end search bar, you need to install two packages:
-- the open-source [React InstantSearch](https://github.com/algolia/react-instantsearch/) library powered by Algolia that provides all the front-end tools you need to highly customize your search bar environment.
+- the open-source [React InstantSearch](https://github.com/algolia/instantsearch/) library powered by Algolia that provides all the front-end tools you need to highly customize your search bar environment.
 - the Meilisearch client [instant-meilisearch](https://github.com/meilisearch/instant-meilisearch/) to establish the communication between your Meilisearch instance and the React InstantSearch library.<br>
 _Instead of reinventing the wheel, we have opted to reuse the InstantSearch library for our own front-end tooling. We will contribute upstream any improvements that may result from our adoption of InstantSearch._
 


### PR DESCRIPTION
The old link points to an archived repository